### PR TITLE
Update Server and Client plans

### DIFF
--- a/plan_client.tf
+++ b/plan_client.tf
@@ -30,17 +30,25 @@ resource "kubernetes_manifest" "client_plan" {
 
       nodeSelector = {
         matchExpressions = [
-          {
-            key      = "node-role.kubernetes.io/control-plane"
-            operator = "DoesNotExist"
-            values   = ["true"]
-          }
+            {
+                key 	= "k3s-upgrade"
+                operator = "Exists"
+            },
+            {
+                key 	= "k3s-upgrade"
+                operator = "NotIn"
+                values 	= ["disabled", "false"]
+            },
+            {
+                key = "node-role.kubernetes.io/control-plane"
+                operator = "DoesNotExist"
+            }
         ]
       }
 
       prepare = {
-        args  = ["prepare", kubernetes_manifest.system_upgrade.manifest.metadata.name]
         image = "rancher/k3s-upgrade"
+        args  = ["prepare", kubernetes_manifest.system_upgrade.manifest.metadata.name]
       }
     }
   }

--- a/plan_server.tf
+++ b/plan_server.tf
@@ -15,7 +15,7 @@ resource "kubernetes_manifest" "system_upgrade" {
       channel            = "https://update.k3s.io/v1-release/channels/${var.k3s_channel}"
       serviceAccountName = "system-upgrade"
 
-      concurrency = var.client_concurrency
+      concurrency = var.server_concurrency
       cordon      = true
 
       drain = {
@@ -30,11 +30,19 @@ resource "kubernetes_manifest" "system_upgrade" {
 
       nodeSelector = {
         matchExpressions = [
-          {
-            key      = "node-role.kubernetes.io/master"
-            operator = "In"
-            values   = ["true"]
-          }
+            {
+                key 	= "k3s-upgrade"
+                operator = "Exists"
+            },
+            {
+                key 	= "node-role.kubernetes.io/control-plane"
+                operator = "Exists"
+            },
+            {
+                key 	= "k3s-upgrade"
+                operator = "NotIn"
+                values 	= ["disabled", "false"]
+            }
         ]
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "client_concurrency" {
   default     = 1
 }
 
+variable "server_concurrency" {
+  type        = number
+  description = "Number of servers to upgrade at a time"
+  default     = 1
+}
+
 variable "force_drain" {
   type        = bool
   description = "Force drain nodes"
@@ -24,13 +30,13 @@ variable "ignore_daemonsets" {
 
 variable "upgrade_controller_version" {
   type        = string
-  default     = "v0.10.0"
+  default     = "v0.11.0"
   description = "The version of the system-upgrade-controller to use."
 }
 
 variable "kubectl_version" {
   type        = string
-  default     = "1.21.9"
+  default     = "1.27.6"
   description = "The version of kubectl to use."
 }
 


### PR DESCRIPTION
- Update kubectl version to stable channel version
- Add server concurrency
  This allows users to increase the client concurrency without
  increasing the server concurrency
- Fix node selectors
